### PR TITLE
use new rgb header to get cRGB type

### DIFF
--- a/src/Kaleidoscope/Focus.h
+++ b/src/Kaleidoscope/Focus.h
@@ -17,6 +17,7 @@
  */
 
 #include <Kaleidoscope.h>
+#include <cRGB.h>
 
 #if FOCUS_WITHOUT_DOCS
 #define FOCUS_HOOK(n, d) ({                               \


### PR DESCRIPTION
refs: https://github.com/keyboardio/Kaleidoscope-Focus/issues/3